### PR TITLE
Modification to expandHyphens.m

### DIFF
--- a/functions/expandHyphens.m
+++ b/functions/expandHyphens.m
@@ -20,6 +20,11 @@
 %                        {'LP4'}
 %                        {'LZ3'}
 %
+% Note: if the first element of a site pair starts with '0', the output will be padded in the tens position
+%       E.g. input {'LP03-LP05'} or {'LP03-LP5'} returns {'LP03'; 'LP04'; 'LP05'}
+%           but input {'LP3-LP05'} will just return {'LP3'; 'LP4'; 'LP5'}.
+%       There is no issue when crossing to double-digit elements. E.g. input {'LP09-LP11'} returns {'LP09'; 'LP10'; 'LP11'} as expected
+%
 % HH 2020
 %
 
@@ -37,10 +42,15 @@ function expandedSites = expandHyphens(sites)
         assert(numel(elements) == 2, sprintf('%s does not contain exactly 1 hyphen', sites{i}));
         
         siteChars = elements{1}(~isDigit(elements{1})); % the characters of the site (e.g. 'LA')
-        numStart = str2double(elements{1}(isDigit(elements{1}))); % the first number of the site
-        numEnd = str2double(elements{2}(isDigit(elements{2}))); % the last number of the site
+        strNumStart = elements{1}(isDigit(elements{1})); % before converting to double, used to check if starts with 0
+        numStart = str2double(strNumStart); % first number of the site
+        numEnd = str2double(elements{2}(isDigit(elements{2}))); % last number of the site
         
-        thisExpandedSite = arrayfun(@(x) sprintf('%s%d', siteChars, x), numStart:numEnd, 'UniformOutput', false)';
+        if startsWith(strNumStart, '0') % pad single digits with '0' in tens place
+            thisExpandedSite = arrayfun(@(x) sprintf('%s%02d', siteChars, x), numStart:numEnd, 'UniformOutput', false)';
+        else
+            thisExpandedSite = arrayfun(@(x) sprintf('%s%d', siteChars, x), numStart:numEnd, 'UniformOutput', false)';
+        end
         expandedSites = [expandedSites; thisExpandedSite(:)];
     end
 end


### PR DESCRIPTION
Minor tweak to expandHyphens (helper function for ieeg_labelSeizure.m) so that it can handle zero-padded electrode sites (e.g. LP08-LP12)