### PR TITLE
Unnecessary casting on high-pass filtering

### DIFF
--- a/functions/ieeg_highpass.m
+++ b/functions/ieeg_highpass.m
@@ -45,7 +45,7 @@ function [signal_hp] = ieeg_highpass(signal, srate, silent)
     for idx_channel = 1:size(signal, 2)
         
         warning('off', 'signal:filtfilt:ParseSOS');
-        signal_hp(:, idx_channel) = single(filtfilt(filtSos, filtOverallGain, double(signal(:, idx_channel))));
+        signal_hp(:, idx_channel) = filtfilt(filtSos, filtOverallGain, double(signal(:, idx_channel)));
         if silent == 0, fprintf(1, '.'); end
         
     end

--- a/functions/ieeg_highpass.m
+++ b/functions/ieeg_highpass.m
@@ -22,34 +22,32 @@ function [signal_hp] = ieeg_highpass(signal, srate, silent)
         signal = signal';
     end
 
-    parameters.SamplingRate.NumericValue = srate;
+    % define the highpass filter passband, stopband, ripple and attenuation
+    passFreq    = 0.50;     % Hz
+    stopFreq    = 0.05;     % Hz
+    passRipple  = 3;        % dB
+    stopAtten   = 30;       % dB
 
-    % --- highpass filter --- 
-    param.highpass.Wp = 0.50; % Hz
-    param.highpass.Ws = 0.05; % Hz
-    param.highpass.Rp = 3;    % dB
-    param.highpass.Rs = 30;   % dB
-
-    % define passband, stopband and attenuation
-    highpass{1}.Wp = param.highpass.Wp / (parameters.SamplingRate.NumericValue / 2); 
-    highpass{1}.Ws = param.highpass.Ws / (parameters.SamplingRate.NumericValue / 2);
-    highpass{1}.Rp = param.highpass.Rp; 
-    highpass{1}.Rs = param.highpass.Rs;
+    % normalize the passband and stopband to the Nyquist frequency
+    normPassFreq = passFreq / (srate / 2); 
+    normStopFreq = stopFreq / (srate / 2);
 
     % calculate the minimum filter order for butterworth filter
-    [highpass{1}.n, highpass{1}.Wn] = buttord(highpass{1}.Wp, highpass{1}.Ws, highpass{1}.Rp, highpass{1}.Rs);
-    highpass{1}.n = highpass{1}.n + rem(highpass{1}.n, 2);
+    [filtOrder, cutFreq] = buttord(normPassFreq, normStopFreq, passRipple, stopAtten);
+    filtOrder = filtOrder + rem(filtOrder, 2);
 
     % calculate the filter coefficients in Zero-Pole-Gain design
-    [highpass{1}.z, highpass{1}.p,highpass{1}.k] = butter(highpass{1}.n, highpass{1}.Wn, 'high');
-    [highpass{1}.sos, highpass{1}.g] = zp2sos(highpass{1}.z, highpass{1}.p, highpass{1}.k);
-    highpass{1}.h = dfilt.df2sos(highpass{1}.sos, highpass{1}.g);
+    [filtZeros, filtPoles, filtGains] = butter(filtOrder, cutFreq, 'high');
+    [filtSos, filtOverallGain] = zp2sos(filtZeros, filtPoles, filtGains);
 
+    % filter the data
     signal_hp = zeros(size(signal));
     for idx_channel = 1:size(signal, 2)
+        
         warning('off', 'signal:filtfilt:ParseSOS');
-        signal_hp(:, idx_channel) = single(filtfilt(highpass{1}.sos, highpass{1}.g, double(signal(:, idx_channel))));
+        signal_hp(:, idx_channel) = single(filtfilt(filtSos, filtOverallGain, double(signal(:, idx_channel))));
         if silent == 0, fprintf(1, '.'); end
+        
     end
     
     if silent == 0, fprintf(1, '] done\n'); end

--- a/functions/ieeg_highpass.m
+++ b/functions/ieeg_highpass.m
@@ -1,52 +1,57 @@
-function [signal_hp] = ieeg_highpass(signal,srate)
+%  Highpass filters the data to deal with DC
 %
-% function [signal_hp] = ieeg_highpass(signal,srate)
+%  [signal_hp] = ieeg_highpass(signal, srate, silent)
+% 
+%      signal       = time X channels;
+%      srate        = sampling frequency
+%      silent       = [optional] flag whether be non verbose
 %
-% highpass filters the data to deal with DC
+%   Returns:
+%      signal_hp    = time X channel
 %
-% inputs
-% signal: time X channel
-% srate: sampling frequency
-%
-% output
-% signal_hp: time X channel
 %
 % code adapted from Brunner lab
 % DH
+%
+function [signal_hp] = ieeg_highpass(signal, srate, silent)
 
+    if exist('silent', 'var') == 0,  silent = 0;     end
+    
+    if size(signal, 1) < size(signal, 2)
+        disp('data may be channels X time, transposing matrix and returning time X channels')
+        signal = signal';
+    end
 
-if size(signal,1)<size(signal,2)
-    disp('data may be channels X time, transposing matrix and returning time X channels')
-    signal = signal';
+    parameters.SamplingRate.NumericValue = srate;
+
+    % --- highpass filter --- 
+    param.highpass.Wp = 0.50; % Hz
+    param.highpass.Ws = 0.05; % Hz
+    param.highpass.Rp = 3;    % dB
+    param.highpass.Rs = 30;   % dB
+
+    % define passband, stopband and attenuation
+    highpass{1}.Wp = param.highpass.Wp / (parameters.SamplingRate.NumericValue / 2); 
+    highpass{1}.Ws = param.highpass.Ws / (parameters.SamplingRate.NumericValue / 2);
+    highpass{1}.Rp = param.highpass.Rp; 
+    highpass{1}.Rs = param.highpass.Rs;
+
+    % calculate the minimum filter order for butterworth filter
+    [highpass{1}.n, highpass{1}.Wn] = buttord(highpass{1}.Wp, highpass{1}.Ws, highpass{1}.Rp, highpass{1}.Rs);
+    highpass{1}.n = highpass{1}.n + rem(highpass{1}.n, 2);
+
+    % calculate the filter coefficients in Zero-Pole-Gain design
+    [highpass{1}.z, highpass{1}.p,highpass{1}.k] = butter(highpass{1}.n, highpass{1}.Wn, 'high');
+    [highpass{1}.sos, highpass{1}.g] = zp2sos(highpass{1}.z, highpass{1}.p, highpass{1}.k);
+    highpass{1}.h = dfilt.df2sos(highpass{1}.sos, highpass{1}.g);
+
+    signal_hp = zeros(size(signal));
+    for idx_channel = 1:size(signal, 2)
+        warning('off', 'signal:filtfilt:ParseSOS');
+        signal_hp(:, idx_channel) = single(filtfilt(highpass{1}.sos, highpass{1}.g, double(signal(:, idx_channel))));
+        if silent == 0, fprintf(1, '.'); end
+    end
+    
+    if silent == 0, fprintf(1, '] done\n'); end
+    
 end
-
-parameters.SamplingRate.NumericValue = srate;
-
-% --- highpass filter --- 
-param.highpass.Wp = 0.50; % Hz
-param.highpass.Ws = 0.05; % Hz
-param.highpass.Rp = 3;    % dB
-param.highpass.Rs = 30;   % dB
-
-% define passband, stopband and attenuation
-highpass{1}.Wp = param.highpass.Wp/(parameters.SamplingRate.NumericValue/2); 
-highpass{1}.Ws = param.highpass.Ws/(parameters.SamplingRate.NumericValue/2);
-highpass{1}.Rp = param.highpass.Rp; 
-highpass{1}.Rs = param.highpass.Rs;
-
-% calculate the minimum filter order for butterworth filter
-[highpass{1}.n,highpass{1}.Wn] = buttord(highpass{1}.Wp,highpass{1}.Ws,highpass{1}.Rp,highpass{1}.Rs);
-highpass{1}.n = highpass{1}.n + rem(highpass{1}.n,2);
-
-% calculate the filter coefficients in Zero-Pole-Gain design
-[highpass{1}.z,highpass{1}.p,highpass{1}.k] = butter(highpass{1}.n,highpass{1}.Wn,'high');
-[highpass{1}.sos,highpass{1}.g] = zp2sos(highpass{1}.z,highpass{1}.p,highpass{1}.k);
-highpass{1}.h = dfilt.df2sos(highpass{1}.sos,highpass{1}.g);
-
-signal_hp = zeros(size(signal));
-for idx_channel = 1:size(signal,2)
-    warning('off', 'signal:filtfilt:ParseSOS');
-    signal_hp(:,idx_channel) = single(filtfilt(highpass{1}.sos,highpass{1}.g,double(signal(:,idx_channel))));
-    fprintf(1,'.');    
-end
-fprintf(1,'] done\n');


### PR DESCRIPTION
Hey Dora,

I formatted the help text and update the variable names, but this update is mainly about the casting (back) to single in the end which causes an unnecessary loss of precision. Has been tested before and after with data.

PS. I also see that my version adds a flag to run silently (default off), optional and always handy to have :)