### PR TITLE
Minor fix, n/a instead of NaN when writing Destrieux columns

### DIFF
--- a/functions/ieeg_labelElectrodesDestrieux.m
+++ b/functions/ieeg_labelElectrodesDestrieux.m
@@ -39,5 +39,6 @@ else
 end
 
 if saveNew==1
+    t_new = bids_tsv_nan2na(t_new);
     writetable(t_new, electrodes_tsv_name, 'FileType','text','Delimiter','\t'); 
 end


### PR DESCRIPTION
Gaby and me found the source of the NaNs. There was already a function that was being used in the steps before, it just wasn't implemented when adding the Destrieux atlas columns.