### PR TITLE
Hold state after ieeg_RenderGifti will be the SAME as before function call

### DIFF
--- a/functions/ieeg_RenderGifti.m
+++ b/functions/ieeg_RenderGifti.m
@@ -19,6 +19,7 @@ elseif ~isempty(varargin)
     c(sulcal_labels<0,:) = 0.7;
 end
 
+holding = ishold; % hold state of axes before rendering gifti
 
 tH = trimesh(g.faces, g.vertices(:,1), g.vertices(:,2), g.vertices(:,3), c); axis equal; hold on
 set(tH, 'LineStyle', 'none', 'FaceColor', 'interp', 'FaceVertexCData',c)
@@ -29,5 +30,6 @@ axis off
 set(gcf,'Renderer', 'zbuffer')
 view(270, 0);
 set(l1,'Position',[-1 0 1])
-hold off
+
+if ~holding, hold off; end
 


### PR DESCRIPTION
figure;
% do stuff
hold on
ieeg_RenderGifti(gii);
% hold state remains on

figure;
ieeg_RenderGifti(gii);
% hold state is off

I'm not sure if this is how built-in functions do it, but we should keep in mind to do something similar with other plotting code moving forward :)