### PR TITLE
updated to include the ceiling of highest vert_label value for colormap

### DIFF
--- a/functions/ieeg_RenderGiftiLabels.m
+++ b/functions/ieeg_RenderGiftiLabels.m
@@ -46,7 +46,7 @@ elseif ~isempty(varargin)
     c(sulcal_labels<0,:) = 0.7;
 end
 
-for k = 1:max(vert_label)
+for k = 1:ceil(max(vert_label))
     c(ceil(vert_label)==k,:) = repmat(cmap(k,:),length(find(ceil(vert_label)==k)),1);
 end
 


### PR DESCRIPTION
Updated line 47 to loop to the ceil of max(vert_label) for colormap. Previously missed the highest vert_label value